### PR TITLE
experiment to handle diffing fusion's manifests

### DIFF
--- a/differ.py
+++ b/differ.py
@@ -5,24 +5,14 @@ import jsondiff
 import pandas as pd
 from functions.flatten import flatten_keys
 from functions import tidy
-from pathlib import Path
-from dbt.cli.flags import Flags
-from dbt.cli.types import Command as CliCommand
-from dbt.flags import set_flags
-
-# Minimal viable imports from dbt-core
-from dbt.contracts.graph.manifest import WritableManifest
+from functions.conform import conform_manifest
+from dbt.artifacts.schemas.manifest import WritableManifest
+from dbt.contracts.graph.manifest import Manifest
 from dbt.graph.selector_methods import StateSelectorMethod
 
-# we need to make sure that `~/.dbt` exists so that settings Flags doesn't crash
-Path("~/.dbt").expanduser().mkdir(exist_ok=True)
-
-flags = Flags.from_dict(CliCommand.LIST, {})
-set_flags(flags)
-
 class MockPreviousState:
-    def __init__(self, manifest: WritableManifest) -> None:
-        self.manifest: Manifest = manifest
+    def __init__(self, manifest: Manifest) -> None:
+        self.manifest = manifest
 
 st.set_page_config(layout="wide")
 st.title("dbt Manifest Differ")
@@ -37,8 +27,8 @@ To avoid false positives, define configs in `dbt_project.yml` instead. See [the 
 """, icon = "💡")
 
 left_col, right_col = st.columns(2)
-left_manifest: WritableManifest = None
-right_manifest: WritableManifest = None
+left_manifest: Manifest = None
+right_manifest: Manifest = None
 
 # Copy-paste from https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/graph/selector_methods.py#L676
 state_options = [
@@ -55,11 +45,13 @@ state_method = st.selectbox(label="State comparison method:", options=state_opti
 properties_to_ignore = st.multiselect("Properties to ignore when showing node-level diffs:", ['created_at', 'root_path', 'build_path', 'compiled_path', 'deferred', 'schema', 'checksum', 'compiled_code', 'database', 'relation_name'], default=['created_at', 'checksum', 'database', 'schema', 'relation_name', 'compiled_path', 'root_path', 'build_path'])
 skipped_large_seeds = set()
 
-def load_manifest(file: UploadedFile) -> WritableManifest:
+def load_manifest(file: UploadedFile) -> Manifest:
     data = json.load(file)
     data, large_seeds = tidy.remove_large_seeds(data)
     skipped_large_seeds.update(large_seeds)
-    return WritableManifest.upgrade_schema_version(data)
+    data = conform_manifest(data)
+    writable = WritableManifest.upgrade_schema_version(data)
+    return Manifest.from_writable_manifest(writable)
 
 left_file = left_col.file_uploader("First manifest", type='json', help="Pick your left json file")
 if left_file is not None:
@@ -73,7 +65,7 @@ if left_file and right_file:
     # TODO: also calculate diffs for sources, exposures, semantic_models, metrics
     included_nodes = set(left_manifest.nodes.keys())
     previous_state = MockPreviousState(right_manifest)
-    state_comparator = StateSelectorMethod(left_manifest, previous_state, "")
+    state_comparator = StateSelectorMethod(left_manifest, previous_state, [])
 
     if len(skipped_large_seeds) > 0:
         st.warning(f"Some large seeds couldn't be compared from the manifest alone: {skipped_large_seeds}" )
@@ -140,7 +132,7 @@ if left_file and right_file:
             try:
                 flattened_diff = flatten_keys(diffs)
                 df = pd.DataFrame.from_dict(flattened_diff, orient='index')
-                st.dataframe(df, use_container_width=True)
+                st.dataframe(df.astype(str), width='stretch')
             except Exception as e:
                 st.error(f"Couldn't print as table: {e}")
         

--- a/differ.py
+++ b/differ.py
@@ -8,7 +8,27 @@ from functions import tidy
 from functions.conform import conform_manifest
 from dbt.artifacts.schemas.manifest import WritableManifest
 from dbt.contracts.graph.manifest import Manifest
-from dbt.graph.selector_methods import StateSelectorMethod
+from dbt.graph.selector_methods import StateSelectorMethod as _StateSelectorMethod
+
+
+class PatchedStateSelectorMethod(_StateSelectorMethod):
+    """Workaround for dbt-core bugs when manifests reference macros or
+    use adapter_type in ways that don't work for cross-version comparison."""
+    def recursively_check_macros_modified(self, node, visited_macros):
+        try:
+            return super().recursively_check_macros_modified(node, visited_macros)
+        except KeyError:
+            # Macro exists in one manifest but not the other — treat as modified
+            return True
+
+    def search(self, included_nodes, selector):
+        try:
+            yield from super().search(included_nodes, selector)
+        except TypeError as e:
+            if "adapter_type" in str(e):
+                return
+            raise
+
 
 class MockPreviousState:
     def __init__(self, manifest: Manifest) -> None:
@@ -61,11 +81,19 @@ right_file = right_col.file_uploader("Second manifest", type='json', help="Pick 
 if right_file is not None:
     right_manifest = load_manifest(right_file)
 
+run_results_file = right_col.file_uploader("CI run results (optional)", type='json', help="Upload run_results.json to filter to only the nodes that were built")
+run_results_nodes = None
+if run_results_file is not None:
+    run_results_data = json.load(run_results_file)
+    run_results_nodes = {r['unique_id'] for r in run_results_data.get('results', [])}
+
 if left_file and right_file:
     # TODO: also calculate diffs for sources, exposures, semantic_models, metrics
     included_nodes = set(left_manifest.nodes.keys())
+    if run_results_nodes is not None:
+        included_nodes = included_nodes & run_results_nodes
     previous_state = MockPreviousState(right_manifest)
-    state_comparator = StateSelectorMethod(left_manifest, previous_state, [])
+    state_comparator = PatchedStateSelectorMethod(left_manifest, previous_state, [])
 
     if len(skipped_large_seeds) > 0:
         st.warning(f"Some large seeds couldn't be compared from the manifest alone: {skipped_large_seeds}" )

--- a/functions/conform.py
+++ b/functions/conform.py
@@ -1,0 +1,320 @@
+"""
+Conform a dbt 2.0-preview manifest dict so it can be deserialized
+by dbt-core 1.11's WritableManifest / mashumaro.
+
+Main issues addressed:
+1. None values in dicts where dbt-core 1.11 expects non-Optional types
+2. Missing `resource_type` field in docs and disabled entries
+3. Missing required fields on some resource types (e.g., `description` on Metric)
+4. Nested None values throughout (in columns, constraints, etc.)
+"""
+
+import dataclasses
+import typing
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+from dbt.artifacts.resources.v1.model import Model
+from dbt.artifacts.resources.v1.seed import Seed
+from dbt.artifacts.resources.v1.analysis import Analysis
+from dbt.artifacts.resources.v1.singular_test import SingularTest
+from dbt.artifacts.resources.v1.generic_test import GenericTest
+from dbt.artifacts.resources.v1.hook import HookNode
+from dbt.artifacts.resources.v1.sql_operation import SqlOperation
+from dbt.artifacts.resources.v1.snapshot import Snapshot
+from dbt.artifacts.resources.v1.source_definition import SourceDefinition
+from dbt.artifacts.resources.v1.exposure import Exposure
+from dbt.artifacts.resources.v1.metric import Metric
+from dbt.artifacts.resources.v1.documentation import Documentation
+from dbt.artifacts.resources.v1.macro import Macro
+from dbt.artifacts.resources.v1.semantic_model import SemanticModel
+from dbt.artifacts.resources.v1.saved_query import SavedQuery
+from dbt.artifacts.resources.v1.unit_test_definition import UnitTestDefinition
+from dbt.artifacts.resources.v1.group import Group
+
+
+def strip_nones(obj: Any) -> Any:
+    """Recursively remove None values from dicts.
+
+    This is intentionally aggressive - after calling this, use
+    ensure_required_fields() to re-add required Optional fields as None.
+    """
+    if isinstance(obj, dict):
+        return {k: strip_nones(v) for k, v in obj.items() if v is not None}
+    elif isinstance(obj, list):
+        return [strip_nones(v) for v in obj]
+    return obj
+
+
+@lru_cache(maxsize=256)
+def _get_resolved_hints(cls: type) -> dict:
+    """Get resolved type hints for a dataclass, handling string annotations."""
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        # Fallback: return raw field types as strings
+        return {}
+
+
+def _is_optional_type(resolved_type: Any) -> bool:
+    """Check if a resolved type is Optional[X] (i.e., Union[X, None])."""
+    origin = getattr(resolved_type, "__origin__", None)
+    args = getattr(resolved_type, "__args__", None)
+    if origin is typing.Union and args and type(None) in args:
+        return True
+    return False
+
+
+def _is_container_type(resolved_type: Any) -> bool:
+    """Check if the type is a dict/list/mapping/sequence container."""
+    origin = getattr(resolved_type, "__origin__", None)
+    if origin in (dict, list, tuple, set, frozenset):
+        return True
+    # Check for typing.Dict, typing.Mapping, etc.
+    if origin is not None:
+        name = getattr(origin, "__name__", "")
+        if name in ("Dict", "Mapping", "List", "Sequence", "Set"):
+            return True
+    return False
+
+
+def _extract_single_dataclass(resolved_type: Any) -> Optional[type]:
+    """Extract a dataclass from a type like X or Optional[X], but NOT from containers."""
+    if _is_container_type(resolved_type):
+        return None
+
+    if isinstance(resolved_type, type) and dataclasses.is_dataclass(resolved_type):
+        return resolved_type
+
+    # Handle Optional[X] / Union[X, None]
+    origin = getattr(resolved_type, "__origin__", None)
+    args = getattr(resolved_type, "__args__", None)
+
+    if origin is typing.Union and args:
+        for arg in args:
+            if arg is type(None):
+                continue
+            if _is_container_type(arg):
+                return None
+            if isinstance(arg, type) and dataclasses.is_dataclass(arg):
+                return arg
+    return None
+
+
+def _extract_list_item_dataclass(resolved_type: Any) -> Optional[type]:
+    """Extract a dataclass from List[X] or Sequence[X]."""
+    origin = getattr(resolved_type, "__origin__", None)
+    args = getattr(resolved_type, "__args__", None)
+
+    if origin in (list,) and args:
+        for arg in args:
+            if isinstance(arg, type) and dataclasses.is_dataclass(arg):
+                return arg
+    return None
+
+
+def _default_for_resolved_type(resolved_type: Any) -> Any:
+    """Return a sensible default for a missing required field given its resolved type."""
+    if _is_optional_type(resolved_type):
+        return None
+
+    type_str = str(resolved_type)
+    if "List" in type_str or "Sequence" in type_str or resolved_type is list:
+        return []
+    if "Dict" in type_str or "Mapping" in type_str or resolved_type is dict:
+        return {}
+    if resolved_type is bool:
+        return False
+    if resolved_type is int:
+        return 0
+    if resolved_type is float:
+        return 0.0
+    return ""
+
+
+def _default_for_field_raw(f: dataclasses.Field) -> Any:
+    """Fallback default using raw (possibly string) type annotation."""
+    type_str = str(f.type)
+    if "Optional" in type_str or "None" in type_str:
+        return None
+    if "List" in type_str or "Sequence" in type_str:
+        return []
+    if "Dict" in type_str or "Mapping" in type_str:
+        return {}
+    if "bool" in type_str:
+        return False
+    if "int" in type_str:
+        return 0
+    if "float" in type_str:
+        return 0.0
+    return ""
+
+
+def ensure_required_fields(entry: dict, cls: type, _seen: Optional[set] = None) -> dict:
+    """Add missing required fields with sensible defaults based on the dataclass.
+
+    Recurses into nested dataclass fields to fix them too.
+    Uses typing.get_type_hints() to resolve string (forward reference) annotations.
+    """
+    if not dataclasses.is_dataclass(cls):
+        return entry
+
+    # Prevent infinite recursion
+    if _seen is None:
+        _seen = set()
+    if id(entry) in _seen:
+        return entry
+    _seen.add(id(entry))
+
+    hints = _get_resolved_hints(cls)
+
+    for f in dataclasses.fields(cls):
+        has_default = (
+            f.default is not dataclasses.MISSING
+            or f.default_factory is not dataclasses.MISSING
+        )
+        resolved = hints.get(f.name)
+
+        if f.name not in entry:
+            if not has_default:
+                if resolved is not None:
+                    entry[f.name] = _default_for_resolved_type(resolved)
+                else:
+                    entry[f.name] = _default_for_field_raw(f)
+        else:
+            # Recurse into nested dataclass fields
+            val = entry[f.name]
+            if resolved is not None:
+                if isinstance(val, dict):
+                    inner_cls = _extract_single_dataclass(resolved)
+                    if inner_cls is not None:
+                        ensure_required_fields(val, inner_cls, _seen)
+                elif isinstance(val, list):
+                    inner_cls = _extract_list_item_dataclass(resolved)
+                    if inner_cls is not None:
+                        for item in val:
+                            if isinstance(item, dict):
+                                ensure_required_fields(item, inner_cls, _seen)
+
+    return entry
+
+
+# Map resource_type string -> dataclass
+_RESOURCE_TYPE_TO_CLASS = {
+    "model": Model,
+    "seed": Seed,
+    "analysis": Analysis,
+    "test": GenericTest,  # both singular and generic use 'test'
+    "operation": HookNode,
+    "sql_operation": SqlOperation,
+    "snapshot": Snapshot,
+    "source": SourceDefinition,
+    "exposure": Exposure,
+    "metric": Metric,
+    "doc": Documentation,
+    "macro": Macro,
+    "semantic_model": SemanticModel,
+    "saved_query": SavedQuery,
+    "unit_test": UnitTestDefinition,
+    "group": Group,
+}
+
+# Map unique_id prefix -> resource_type value
+_PREFIX_TO_RESOURCE_TYPE = {
+    "model": "model",
+    "seed": "seed",
+    "analysis": "analysis",
+    "test": "test",
+    "operation": "operation",
+    "snapshot": "snapshot",
+    "source": "source",
+    "exposure": "exposure",
+    "metric": "metric",
+    "doc": "doc",
+    "macro": "macro",
+    "semantic_model": "semantic_model",
+    "saved_query": "saved_query",
+    "unit_test": "unit_test",
+    "group": "group",
+}
+
+# Map manifest section -> dataclass (for sections with a uniform type)
+_SECTION_CLASS = {
+    "sources": SourceDefinition,
+    "exposures": Exposure,
+    "metrics": Metric,
+    "docs": Documentation,
+    "macros": Macro,
+    "semantic_models": SemanticModel,
+    "saved_queries": SavedQuery,
+    "unit_tests": UnitTestDefinition,
+    "groups": Group,
+}
+
+
+def _infer_resource_type(unique_id: str) -> Optional[str]:
+    """Infer resource_type from the unique_id prefix."""
+    prefix = unique_id.split(".")[0] if unique_id else None
+    return _PREFIX_TO_RESOURCE_TYPE.get(prefix)
+
+
+def _fix_entry(entry: dict, cls: type) -> dict:
+    """Fix a single manifest entry: ensure required fields exist."""
+    ensure_required_fields(entry, cls)
+    return entry
+
+
+def _fix_node(entry: dict) -> dict:
+    """Fix a node entry (from 'nodes' or 'disabled' sections)."""
+    rt = entry.get("resource_type")
+    if rt is None:
+        uid = entry.get("unique_id", "")
+        rt = _infer_resource_type(uid)
+        if rt is not None:
+            entry["resource_type"] = rt
+
+    cls = _RESOURCE_TYPE_TO_CLASS.get(rt)
+    if cls is not None:
+        _fix_entry(entry, cls)
+    return entry
+
+
+def conform_manifest(data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Preprocess raw manifest JSON dict to make it compatible with
+    dbt-core 1.11's WritableManifest deserialization.
+    """
+    # 1. Recursively strip None values (fixes non-Optional fields that got None)
+    data = strip_nones(data)
+
+    # 2. Fix nodes section
+    nodes = data.get("nodes", {})
+    for key in nodes:
+        _fix_node(nodes[key])
+
+    # 3. Fix typed sections (sources, exposures, metrics, etc.)
+    for section_name, cls in _SECTION_CLASS.items():
+        section = data.get(section_name, {})
+        if isinstance(section, dict):
+            for key in section:
+                entry = section[key]
+                # Ensure resource_type is set
+                if "resource_type" not in entry:
+                    uid = entry.get("unique_id", "")
+                    rt = _infer_resource_type(uid)
+                    if rt is not None:
+                        entry["resource_type"] = rt
+                _fix_entry(entry, cls)
+
+    # 4. Fix disabled section
+    disabled = data.get("disabled", {})
+    if isinstance(disabled, dict):
+        for key in disabled:
+            items = disabled[key]
+            if isinstance(items, list):
+                for item in items:
+                    _fix_node(item)
+            else:
+                _fix_node(items)
+
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 streamlit
-dbt-core~=1.7.0
-dbt-common
+dbt-core~=1.11.0
 jsondiff==2.0.0


### PR DESCRIPTION
- move to dbt core 1.11 instead of 1.7
- process v12 manifests generated by dbt fusion engine so that they are compatible with the v12 that dbt core expects 

Note: in some cases, manifests produced by fusion contain `raw_code: --placeholder--`. I think it's when deferring to a run which didn't work with any models (e.g. a run_operation). So I've added the ability to upload a run_results.json which will narrow it down to just the nodes that were actually built in the CI run. 
- But this caused its own issues, which needed patching the StateSelectorMethod